### PR TITLE
add mono to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN echo "deb http://http.us.debian.org/debian/ testing contrib main" >> /etc/ap
     chown root:root /etc/apt/trusted.gpg.d/microsoft.asc.gpg && \
     chown root:root /etc/apt/sources.list.d/microsoft-prod.list && \
     apt-get update && \
-    apt-get install -y --no-install-recommends default-jre apt-transport-https aspnetcore-runtime-2.1 && \
+    apt-get install -y --no-install-recommends default-jre apt-transport-https aspnetcore-runtime-2.1 mono-complete && \
     apt-get -t testing install -y --no-install-recommends python3.7 python3-distutils && \
     curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
     python3.7 get-pip.py && \


### PR DESCRIPTION
Please add mono to the docker image,  that way I can use .net framework 4.x runtime