### PR TITLE
Use regular python instead of one from testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,7 @@ LABEL "repository"="https://github.com/Secbyte/dotnet-sonarscanner"
 LABEL "homepage"="https://github.com/Secbyte/dotnet-sonarscanner"
 LABEL "maintainer"="Joshua Duffy <mail@joshuaduffy.org>"
 
-RUN echo "deb http://http.us.debian.org/debian/ testing contrib main" >> /etc/apt/sources.list && \
-    wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.asc.gpg && \
+RUN wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.asc.gpg && \
     mv microsoft.asc.gpg /etc/apt/trusted.gpg.d/ && \
     wget -q https://packages.microsoft.com/config/debian/10/prod.list && \
     mv prod.list /etc/apt/sources.list.d/microsoft-prod.list && \
@@ -18,9 +17,7 @@ RUN echo "deb http://http.us.debian.org/debian/ testing contrib main" >> /etc/ap
     chown root:root /etc/apt/sources.list.d/microsoft-prod.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends default-jre apt-transport-https aspnetcore-runtime-2.1 mono-complete && \
-    apt-get -t testing install -y --no-install-recommends python3.7 python3-distutils && \
-    curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
-    python3.7 get-pip.py && \
+    apt-get install -y --no-install-recommends python3 python3-distutils python3-pip python3-setuptools && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* && \
     apt-get autoremove -y && \
     dotnet tool install dotnet-sonarscanner --tool-path . --version 4.7.1


### PR DESCRIPTION
Install Python from main repository instead of testing to fix: `ModuleNotFoundError: No module named 'distutils.util'`